### PR TITLE
Allow using default identity file during SSHing when node has public IP

### DIFF
--- a/script_ssh.sh
+++ b/script_ssh.sh
@@ -98,6 +98,20 @@ else [ "$KUBECTL_PLUGINS_LOCAL_FLAG_CLOUD_PROVIDER" == "aws" ]
       esac
     done
   else
-    [[ ! -z "${IP}" ]] && echo "SSHing into Worker Node with IP: ${IP}" && ssh -i ${KUBECTL_PLUGINS_LOCAL_FLAG_IDENTITY_FILE} ${KUBECTL_PLUGINS_LOCAL_FLAG_SSH_USER}@$IP || echo "Can't SSH"; exit 1;
+    if [ ! -z "${IP}" ]
+    then
+      if [ "${KUBECTL_PLUGINS_LOCAL_FLAG_IDENTITY_FILE}" == "" ]
+      then
+        echo "SSHing into Worker Node using default identity file with IP: ${IP}"
+        ssh ${KUBECTL_PLUGINS_LOCAL_FLAG_SSH_USER}@$IP || echo "Can't SSH"; exit 1;
+      elif [ ! -z "${IP}" ]
+      then
+        echo "SSHing into Worker Node with IP: ${IP}"
+        ssh -i ${KUBECTL_PLUGINS_LOCAL_FLAG_IDENTITY_FILE} ${KUBECTL_PLUGINS_LOCAL_FLAG_SSH_USER}@$IP || echo "Can't SSH"; exit 1;
+      fi
+    else
+      echo "Cannot find IP address of node."
+      exit 1;
+    fi
   fi
 fi


### PR DESCRIPTION
When user doesn't provide `-i` flag, default identity-file could be used as SSH does. (The default is ~/.ssh/id_dsa, ~/.ssh/id_ecdsa, ~/.ssh/id_ed25519 and ~/.ssh/id_rsa.)

This PR added to use default identity-file when node has public IP.